### PR TITLE
feat: removal of nightly-only feature and refactor for OB support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+# If on Windows, add the .exe extension to the executable and use PowerShell instead of `sed`
+ifeq ($(OS),Windows_NT)
+	EXT := .exe
+	NAME := $(shell powershell -Command "(Get-Content yukari/Cargo.toml | Select-String '^name =').Line -replace '.*= ', '' -replace '\"', ''")
+	VERSION := $(shell powershell -Command "(Get-Content yukari/Cargo.toml | Select-String '^version =').Line -replace '.*= ', '' -replace '\"', ''")
+else
+	EXT := 
+	NAME := $(shell sed -n 's/^name = "\(.*\)"/\1/p' yukari/Cargo.toml | head -1)
+	VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' yukari/Cargo.toml | head -1)
+
+endif
+
+# OpenBench specifies that the binary name should be changeable with the EXE parameter
+ifndef EXE
+	EXE := $(NAME)-$(VERSION)$(EXT)
+else
+	EXE := $(EXE)$(EXT)
+endif
+
+
+
+# Compile an executable for use with OpenBench
+openbench:
+	@echo $(NAME)
+	@echo Compiling $(EXE) for OpenBench
+	cargo rustc --release --manifest-path yukari/Cargo.toml --bin yukari -- -C target-cpu=native --emit link=$(EXE)
+
+# Remove the EXE created
+clean:
+	@echo Removing $(EXE)
+	rm $(EXE)

--- a/yukari-movegen/src/board/data.rs
+++ b/yukari-movegen/src/board/data.rs
@@ -101,7 +101,11 @@ impl BoardData {
 
     /// Given a piece index, return its piece type.
     pub const fn piece_from_bit(&self, bit: PieceIndex) -> Piece {
-        self.piecemask.piece(bit).expect("piece index corresponds to invalid piece")
+        if let Some(piece) = self.piecemask.piece(bit) {
+            piece
+        } else {
+            panic!("piece index corresponds to invalid piece");
+        }
     }
 
     /// Given a square, return the piece type of it, if any.

--- a/yukari/examples/bench.rs
+++ b/yukari/examples/bench.rs
@@ -78,5 +78,6 @@ fn main() {
         nodes += s.nodes() + s.qnodes();
     }
     let now = Instant::now().duration_since(start);
-    println!("{nodes} nodes in {:.3}s = {:.0} nodes/s", now.as_secs_f64(), (nodes as f64) / now.as_secs_f64());
+    let nps = (nodes as f64 / now.as_secs_f64()) as u64;
+    println!("{nodes} nodes {nps} nps");
 }

--- a/yukari/src/main.rs
+++ b/yukari/src/main.rs
@@ -189,7 +189,8 @@ impl Yukari {
             nodes += s.nodes() + s.qnodes();
         }
         let now = Instant::now().duration_since(start);
-        println!("{nodes} nodes in {:.3}s = {:.0} nodes/s", now.as_secs_f64(), (nodes as f64) / now.as_secs_f64());
+        let nps = (nodes as f64 / now.as_secs_f64()) as u64;
+        println!("{nodes} nodes {nps} nps");
     }
 
     fn nnue_label(&mut self, tt: &mut [TtEntry]) {


### PR DESCRIPTION
These are all changes I needed to make in order to test Yukari with OpenBench. I'm just making this PR so you can reference these changes in the future, should you ever want to use OpenBench.

- Removes the dependency on `const Option::unwrap` which is not yet stable in Rust (as of `1.82.0`).
- Refactors the output of the `bench` command to be compatible with OpenBench.
- Adds a `Makefile` to build Yukari with `make` (required by OpenBench)

OB has [a few ways to parse bench commands](https://github.com/AndyGrant/OpenBench/blob/master/Client/bench.py#L54) but none of them covered Yukari's `nodes/s` format.