### PR TITLE
Add TT prefetch for x86_64

### DIFF
--- a/yukari-movegen/src/board/mod.rs
+++ b/yukari-movegen/src/board/mod.rs
@@ -1051,6 +1051,99 @@ impl Board {
         self.data.hash()
     }
 
+    #[inline]
+    #[must_use]
+    #[allow(clippy::too_many_lines)]
+    pub fn hash_after(&self, m: Move) -> u64 {
+        let mut hash = self.hash();
+
+        match m.kind {
+            MoveType::Promotion | MoveType::Normal | MoveType::DoublePush => {}
+            MoveType::Capture | MoveType::CapturePromotion => {
+                let piece_index =
+                    self.data.piece_index(m.dest).unwrap_or_else(|| panic!("move {m} attempts to capture an empty square"));
+                Zobrist::remove_piece(piece_index.colour(), self.data.piece_from_bit(piece_index), self.data.square_of_piece(piece_index), &mut hash);
+            }
+            MoveType::Castle => {
+                let (rook_from, rook_to) = if m.dest > m.from {
+                    (m.dest.east().unwrap(), m.dest.west().unwrap())
+                } else {
+                    (m.dest.west().unwrap().west().unwrap(), m.dest.east().unwrap())
+                };
+                let piece_index = self.data.piece_index(rook_from).unwrap();
+                Zobrist::move_piece(piece_index.colour(), self.data.piece_from_bit(piece_index), rook_from, rook_to, &mut hash);
+            }
+            MoveType::EnPassant => {
+                let target_square = self.ep.unwrap().relative_south(self.side).unwrap();
+                let target_piece = self.data.piece_index(target_square).unwrap();
+                Zobrist::remove_piece(target_piece.colour(), self.data.piece_from_bit(target_piece), self.data.square_of_piece(target_piece), &mut hash);
+            }
+        }
+
+        let piece_index = self.data.piece_index(m.from).unwrap();
+        Zobrist::move_piece(self.side, self.piece_from_bit(piece_index), m.from, m.dest, &mut hash);
+
+        if matches!(m.kind, MoveType::Promotion | MoveType::CapturePromotion) {
+            Zobrist::remove_piece(self.side, self.data.piece_from_bit(piece_index), self.data.square_of_piece(piece_index), &mut hash);
+            Zobrist::add_piece(self.side, m.prom.unwrap(), m.dest, &mut hash);
+        }
+
+        let candidate_ep = (|| {
+            let MoveType::DoublePush = m.kind else { return None };
+            let candidate_ep = m.from.relative_north(self.side)?;
+            let attacks = self.data().attacks_to(candidate_ep, !self.side());
+            if (attacks & self.data().piecemask().pawns()).empty() {
+                return None;
+            }
+            Some(candidate_ep)
+        })();
+        Zobrist::set_ep(self.ep, candidate_ep, &mut hash);
+
+        let a1 = Square::from_rank_file(Rank::One, File::A);
+        let a8 = Square::from_rank_file(Rank::Eight, File::A);
+        let e1 = Square::from_rank_file(Rank::One, File::E);
+        let e8 = Square::from_rank_file(Rank::Eight, File::E);
+        let h1 = Square::from_rank_file(Rank::One, File::H);
+        let h8 = Square::from_rank_file(Rank::Eight, File::H);
+
+        if m.from == e1 {
+            if self.castle.0 {
+                Zobrist::remove_castling(0, &mut hash);
+            }
+            if self.castle.1 {
+                Zobrist::remove_castling(1, &mut hash);
+            }
+        }
+
+        if m.from == e8 {
+            if self.castle.2 {
+                Zobrist::remove_castling(2, &mut hash);
+            }
+            if self.castle.3 {
+                Zobrist::remove_castling(3, &mut hash);
+            }
+        }
+
+        if (m.from == h1 || m.dest == h1) && self.castle.0 {
+            Zobrist::remove_castling(0, &mut hash);
+        }
+
+        if (m.from == a1 || m.dest == a1) && self.castle.1 {
+            Zobrist::remove_castling(1, &mut hash);
+        }
+
+        if (m.from == h8 || m.dest == h8) && self.castle.2 {
+            Zobrist::remove_castling(2, &mut hash);
+        }
+
+        if (m.from == a8 || m.dest == a8) && self.castle.3 {
+            Zobrist::remove_castling(3, &mut hash);
+        }
+
+        Zobrist::toggle_side(&mut hash);
+        hash
+    }
+
     #[must_use]
     pub fn hash_pawns(&self) -> u64 {
         self.data.hash_pawns()

--- a/yukari-movegen/src/board/mod.rs
+++ b/yukari-movegen/src/board/mod.rs
@@ -1084,7 +1084,7 @@ impl Board {
         Zobrist::move_piece(self.side, self.piece_from_bit(piece_index), m.from, m.dest, &mut hash);
 
         if matches!(m.kind, MoveType::Promotion | MoveType::CapturePromotion) {
-            Zobrist::remove_piece(self.side, self.data.piece_from_bit(piece_index), self.data.square_of_piece(piece_index), &mut hash);
+            Zobrist::remove_piece(self.side, self.data.piece_from_bit(piece_index), m.dest, &mut hash);
             Zobrist::add_piece(self.side, m.prom.unwrap(), m.dest, &mut hash);
         }
 

--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, sync::atomic::AtomicU64, time::Instant};
 use tinyvec::ArrayVec;
 use yukari_movegen::{Board, Colour, Move, Piece};
 
-// #[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
 
 const MATE_VALUE: i32 = 10_000;
@@ -445,17 +445,17 @@ impl<'a> Search<'a> {
         None
     }
 
+    #[cfg(target_arch = "x86_64")]
     #[inline(always)]
-    // #[cfg(target_arch = "x86_64")]
     fn prefetch_tt(&self, board: &Board, m: Move) {
         let entry = (board.hash_after(m) & ((self.tt.len() - 1) as u64)) as usize;
         let entry = &self.tt[entry];
         unsafe { _mm_prefetch::<_MM_HINT_T0>(entry as *const _ as *const i8) }
     }
 
-    // #[inline(always)]
-    // #[cfg(not(target_arch = "x86_64"))]
-    // fn prefetch_tt(&self, board: &Board, m: Move) {}
+    #[cfg(not(target_arch = "x86_64"))]
+    #[inline(always)]
+    fn prefetch_tt(&self, board: &Board, m: Move) {}
 
     fn write_tt(&self, board: &Board, ply: i32, mut data: TtData) {
         let entry = (board.hash() & ((self.tt.len() - 1) as u64)) as usize;

--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, sync::atomic::AtomicU64, time::Instant};
 use tinyvec::ArrayVec;
 use yukari_movegen::{Board, Colour, Move, Piece};
 
-#[cfg(target_arch = "x86_64")]
+// #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
 
 const MATE_VALUE: i32 = 10_000;
@@ -446,16 +446,16 @@ impl<'a> Search<'a> {
     }
 
     #[inline(always)]
-    #[cfg(target_arch = "x86_64")]
+    // #[cfg(target_arch = "x86_64")]
     fn prefetch_tt(&self, board: &Board, m: Move) {
         let entry = (board.hash_after(m) & ((self.tt.len() - 1) as u64)) as usize;
         let entry = &self.tt[entry];
         unsafe { _mm_prefetch::<_MM_HINT_T0>(entry as *const _ as *const i8) }
     }
 
-    #[inline(always)]
-    #[cfg(not(target_arch = "x86_64"))]
-    fn prefetch_tt(&self, board: &Board, m: Move) {}
+    // #[inline(always)]
+    // #[cfg(not(target_arch = "x86_64"))]
+    // fn prefetch_tt(&self, board: &Board, m: Move) {}
 
     fn write_tt(&self, board: &Board, ply: i32, mut data: TtData) {
         let entry = (board.hash() & ((self.tt.len() - 1) as u64)) as usize;

--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -3,6 +3,9 @@ use std::{cmp::Ordering, sync::atomic::AtomicU64, time::Instant};
 use tinyvec::ArrayVec;
 use yukari_movegen::{Board, Colour, Move, Piece};
 
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
+
 const MATE_VALUE: i32 = 10_000;
 
 #[derive(Clone)]
@@ -442,6 +445,18 @@ impl<'a> Search<'a> {
         None
     }
 
+    #[inline(always)]
+    #[cfg(target_arch = "x86_64")]
+    fn prefetch_tt(&self, board: &Board, m: Move) {
+        let entry = (board.hash_after(m) & ((self.tt.len() - 1) as u64)) as usize;
+        let entry = &self.tt[entry];
+        unsafe { _mm_prefetch::<_MM_HINT_T0>(entry as *const _ as *const i8) }
+    }
+
+    #[inline(always)]
+    #[cfg(not(target_arch = "x86_64"))]
+    fn prefetch_tt(&self, board: &Board, m: Move) {}
+
     fn write_tt(&self, board: &Board, ply: i32, mut data: TtData) {
         let entry = (board.hash() & ((self.tt.len() - 1) as u64)) as usize;
         let entry = &self.tt[entry];
@@ -716,6 +731,8 @@ impl<'a> Search<'a> {
                     extension += 1;
                 }
             }
+
+            self.prefetch_tt(board, m);
 
             self.path.push(Some((board.piece_from_square(m.from).unwrap(), m)));
 


### PR DESCRIPTION
```
Elo   | 2.93 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21332 W: 4279 L: 4099 D: 12954
Penta | [108, 2143, 6006, 2279, 130]
```
https://pyronomy.pythonanywhere.com/test/3352/
```
Elo   | 4.82 +- 3.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8724 W: 1664 L: 1543 D: 5517
Penta | [16, 777, 2659, 890, 20]
```
https://pyronomy.pythonanywhere.com/test/3353/

bench: 5531990