### PR TITLE
Low depth singular extension

### DIFF
--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -499,6 +499,9 @@ impl Thread {
                     if score < singular_beta {
                         extension += 1;
                     }
+                // Low depth singular extension: Determine singularity by static eval vs alpha.
+                } else if !self.board[ply].in_check() && depth <= 7 && eval <= alpha - 25 && tt_entry.flags == TtFlags::Lower {
+                    extension += 1;
                 }
             }
 


### PR DESCRIPTION
Passed STC:
```
Elo   | 2.72 +- 2.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 28012 W: 5516 L: 5297 D: 17199
Penta | [216, 3159, 7039, 3374, 218]
```
https://pyronomy.pythonanywhere.com/test/3773/

Passed LTC:
```
Elo   | 5.55 +- 3.83 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8634 W: 1719 L: 1581 D: 5334
Penta | [34, 953, 2226, 1049, 55]
```
https://pyronomy.pythonanywhere.com/test/3776/

bench: 987791