### PR TITLE
beta negative extension

### DIFF
--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -498,6 +498,8 @@ impl Thread {
                     // The TT move seems uniquely good; extend.
                     if score < singular_beta {
                         extension += 1;
+                    } else if tt_entry.score as i32 >= beta {
+                        extension -= 1;
                     }
                 // Low depth singular extension: Determine singularity by static eval vs alpha.
                 } else if !self.board[ply].in_check() && depth <= 7 && eval <= alpha - 25 && tt_entry.flags == TtFlags::Lower {


### PR DESCRIPTION
beta negative extension

Passed STC:
Elo   | 4.72 +- 3.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11252 W: 2222 L: 2069 D: 6961
Penta | [76, 1255, 2820, 1390, 85]

Passed LTC:
Elo   | 4.45 +- 3.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11332 W: 2175 L: 2030 D: 7127
Penta | [42, 1238, 2969, 1367, 50]

bench: 992296