### PR TITLE
Double extension

### DIFF
--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -559,6 +559,9 @@ impl Thread {
                     // The TT move seems uniquely good; extend.
                     if score < singular_beta {
                         extension += 1;
+                        if !expected_pvnode && score < singular_beta - 20 && tt_entry.depth as i32 >= depth - 2 {
+                            extension += 1;
+                        }
                     } else if tt_entry.score as i32 >= beta {
                         extension -= 1;
                     }


### PR DESCRIPTION
STC
Elo   | 4.63 +- 3.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11940 W: 2647 L: 2488 D: 6805
Penta | [83, 1381, 2893, 1520, 93]

LTC
Elo   | 8.77 +- 5.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4834 W: 1065 L: 943 D: 2826
Penta | [17, 515, 1231, 637, 17]

2x crashes at LTC.

Bench: 2629383