### PR TITLE
Double extension

### DIFF
--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -12,6 +12,8 @@ use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use tinyvec::ArrayVec;
 use yukari_movegen::{Board, Colour, Move, Piece};
 
+const MAX_PLY: usize = 240;
+
 const MATE_VALUE: i32 = 10_000;
 
 // TODO: when 50-move rule is implemented, this can be limited to searching from the last irreversible move.
@@ -199,6 +201,10 @@ impl Thread {
 
     pub fn quiesce(&mut self, mut alpha: i32, beta: i32, ply: usize, tt: &[TtEntry]) -> i32 {
         let expected_pvnode = alpha != beta - 1;
+
+        if ply >= MAX_PLY {
+            return self.eval(ply);
+        }
 
         if self.pv.len() <= ply {
             self.pv.push(Vec::new());
@@ -402,6 +408,10 @@ impl Thread {
         &mut self, depth: i32, mut alpha: i32, beta: i32, ply: usize, tt: &[TtEntry], excluded_move: Option<Move>,
     ) -> i32 {
         let expected_pvnode = alpha != beta - 1;
+
+        if ply >= MAX_PLY {
+            return self.eval(ply);
+        }
 
         if self.pv.len() <= ply {
             self.pv.push(Vec::new());

--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -559,6 +559,9 @@ impl Thread {
                     // The TT move seems uniquely good; extend.
                     if score < singular_beta {
                         extension += 1;
+                        if !expected_pvnode && score < singular_beta - 20 && tt_entry.depth as i32 >= depth - 2 {
+                            extension += 1;
+                        }
                     } else if tt_entry.score as i32 >= beta {
                         extension -= 1;
                     }

--- a/yukari/src/search.rs
+++ b/yukari/src/search.rs
@@ -559,7 +559,7 @@ impl Thread {
                     // The TT move seems uniquely good; extend.
                     if score < singular_beta {
                         extension += 1;
-                        if !expected_pvnode && score < singular_beta - 20 && tt_entry.depth as i32 >= depth - 2 {
+                        if !expected_pvnode && score < singular_beta - 50 && tt_entry.depth as i32 >= depth - 2 {
                             extension += 1;
                         }
                     } else if tt_entry.score as i32 >= beta {


### PR DESCRIPTION
STC
Elo | 4.63 +- 3.42 (95%)
SPRT | 8.0+0.08s Threads=1 Hash=16MB
LLR | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11940 W: 2647 L: 2488 D: 6805
Penta | [83, 1381, 2893, 1520, 93]

LTC
Elo | 8.77 +- 5.05 (95%)
SPRT | 40.0+0.40s Threads=1 Hash=128MB
LLR | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4834 W: 1065 L: 943 D: 2826
Penta | [17, 515, 1231, 637, 17]

2x crashes at LTC.

Bench: 2445677